### PR TITLE
Make StringBuilder local var instead of member

### DIFF
--- a/src/Apod/Logic/Net/ApodUriBuilder.cs
+++ b/src/Apod/Logic/Net/ApodUriBuilder.cs
@@ -10,15 +10,11 @@ namespace Apod.Logic.Net
         private readonly string _baseUri;
         private readonly string _dateFormat;
 
-        private readonly StringBuilder _stringBuilder;
-
         public ApodUriBuilder(string apiKey, string baseUri = "https://api.nasa.gov/planetary/apod", string dateFormat = "yyyy-MM-dd")
         {
             _apiKey = apiKey;
             _baseUri = baseUri;
             _dateFormat = dateFormat;
-
-            _stringBuilder = new StringBuilder();
         }
 
         public string GetApodUri() 
@@ -36,16 +32,18 @@ namespace Apod.Logic.Net
 
         private string BuildUri(params string[] queryParameters)
         {
-            _stringBuilder.Append(_baseUri).Append("?api_key=").Append(_apiKey);
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.Append(_baseUri).Append("?api_key=").Append(_apiKey);
 
             foreach (var parameter in queryParameters)
             {
                 if (string.IsNullOrWhiteSpace(parameter)) { continue; }
-                _stringBuilder.Append("&");
-                _stringBuilder.Append(parameter);
+                stringBuilder.Append("&");
+                stringBuilder.Append(parameter);
             }
 
-            return _stringBuilder.ToString();
+            return stringBuilder.ToString();
         }
     }
 }

--- a/src/ApodTests/ApodUriBuilderTests.cs
+++ b/src/ApodTests/ApodUriBuilderTests.cs
@@ -125,5 +125,20 @@ namespace ApodTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void GetApodUri_SameResultEveryTime()
+        {
+            var uriBuilder = new ApodUriBuilder("exampleKey");
+
+            var expected = "https://api.nasa.gov/planetary/apod?api_key=exampleKey";
+
+            // Run 3 times and make sure the result doesn't change
+            for (int i = 0; i < 3; i++)
+            {
+                var actual = uriBuilder.GetApodUri();
+                Assert.Equal(expected, actual);
+            }            
+        }
     }
 }


### PR DESCRIPTION
I was wrong about #18 having to do with objects not being disposed of correctly. The problem was that the ApodUriBuilder preserved the instance of the StringBuilder between requests, and since the URI was appended to the StringBuilder every time the URI was doubled which obviously did not work. This has been fixed by making the StringBuilder a local variable that is instantiated when the method is called.

Closes #18 