### PR TITLE
Try new environment variable name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       run: dotnet pack src/Apod/Apod.csproj -c Release --output nupkgs
       
     - name: Publish NuGet package
-      run: dotnet nuget push nupkgs\*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ env.NUGET_KEY }}
+      run: dotnet nuget push nupkgs\*.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_KEY
       env:
         NUGET_KEY: ${{ secrets.NUGET_API_KEY }}
       


### PR DESCRIPTION
It's now in all caps, even though the example showed environment variables in lowercase too.