### PR TITLE
[CD TEST] Remove setApiKey

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,6 @@ jobs:
     - name: Push package to the Github Package Registry
       run: |        
         nuget sources Add -Name "GPR" -Source "https://nuget.pkg.github.com/lemorrow/index.json" -UserName LeMorrow -Password ${{ secrets.GITHUB_TOKEN }}
-        nuget setApiKey ${{ secrets.NUGET_API_KEY }} -Source "GPR"
         nuget push nupkg/*.nupkg -Source "GPR" -SkipDuplicate
 
   # Generates the documentation with DocFX and uploads the static website as an artifact


### PR DESCRIPTION
This is an attempt to deploy to GPR from `ubuntu-latest`.

A working example by Tim Heuer [here](https://github.com/NuGet/Home/issues/8580#issuecomment-566236599) omits the `setApiKey` command as it is not required. This pull request removes that line in an attempt to solve the error mentioned in the issue.

The previous commit https://github.com/LeMorrow/APOD.Net/commit/a9540c4534226fe55675080c315a245b4d5212dd updated the `NuGet/setup-nuget` version from `1` to `1.0.2` (like Tim Heuer's example) without success.