### PR TITLE
[CD TEST] Remove nuget-api-key and increase verbosity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,13 +55,12 @@ jobs:
 
     - uses: NuGet/setup-nuget@v1.0.2
       with:
-        nuget-api-key: ${{ secrets.NUGET_API_KEY }}
         nuget-version: 'latest'
     
     - name: Push package to the Github Package Registry
       run: |        
         nuget sources Add -Name "GPR" -Source "https://nuget.pkg.github.com/lemorrow/index.json" -UserName LeMorrow -Password ${{ secrets.GITHUB_TOKEN }}
-        nuget push nupkg/*.nupkg -Source "GPR" -SkipDuplicate
+        nuget push nupkg/*.nupkg -Source "GPR" -SkipDuplicate -Verbosity detailed
 
   # Generates the documentation with DocFX and uploads the static website as an artifact
   generate_docs:


### PR DESCRIPTION
Suggested by Tim Heuer to debug nuget push on ubuntu-latest in a GitHub Action using NuGet/setup-nuget. As to not spam the issue in the [NuGet/Home](https://github.com/NuGet/Home) with pull requests and commits I will not link the issue here. You can look for issue number 8580 by `jwillmer` opened on Sep 12, 2019 for more context.